### PR TITLE
shadPS4 support

### DIFF
--- a/include/plugin_common.h
+++ b/include/plugin_common.h
@@ -6,3 +6,5 @@ static struct proc_info procInfo;
 bool file_exists(const char*);
 
 float read_file_as_float(const char*);
+
+uint64_t get_base_address();

--- a/source/Autoplay.c
+++ b/source/Autoplay.c
@@ -59,12 +59,12 @@ void RBVocalPlayerRestart_hook(void* thisRBVocalPlayer, float time, void* song) 
 
 void InitAutoplayHooks()
 {
-    sys_sdk_proc_info(&procInfo);
+    uint64_t base_address = get_base_address();
 
-    SetGameOver = (void*)(procInfo.base_address + 0x00a48790);
-    SetCheating = (void*)(procInfo.base_address + 0x0122dfc0);
-    SetAutoplay = (void*)(procInfo.base_address + 0x00a65680);
-    RBVocalPlayerRestart = (void*)(procInfo.base_address + 0x00a622f0);
+    SetGameOver = (void*)(base_address + 0x00a48790);
+    SetCheating = (void*)(base_address + 0x0122dfc0);
+    SetAutoplay = (void*)(base_address + 0x00a65680);
+    RBVocalPlayerRestart = (void*)(base_address + 0x00a622f0);
 
     HOOK(SetGameOver);
     HOOK(SetCheating);

--- a/source/DTAFuncs.c
+++ b/source/DTAFuncs.c
@@ -328,16 +328,16 @@ void RBSystemOptionsSave_hook(void* thisoptions, void* binstream) {
 }
 
 void InitDTAHooks() {
-    sys_sdk_proc_info(&procInfo);
+    uint64_t base_address = get_base_address();
 
-    DataInitFuncs = (void*)(procInfo.base_address + 0x00222350);
-    DataRegisterFunc = (void*)(procInfo.base_address + 0x002221f0);
-    DataArrayEvaluate = (void*)(procInfo.base_address + 0x000c7d30);
-    DataNodeForceSym = (void*)(procInfo.base_address + 0x0000e850);
-    DataNodeFloat = (void*)(procInfo.base_address + 0x0000ee30);
-    Symbol_Ctor = (void*)(procInfo.base_address + 0x00256fd0);
-    SystemOptionsLoad = (void*)(procInfo.base_address + 0x011b2310);
-    RBSystemOptionsSave = (void*)(procInfo.base_address + 0x00d667c0);
+    DataInitFuncs = (void*)(base_address + 0x00222350);
+    DataRegisterFunc = (void*)(base_address + 0x002221f0);
+    DataArrayEvaluate = (void*)(base_address + 0x000c7d30);
+    DataNodeForceSym = (void*)(base_address + 0x0000e850);
+    DataNodeFloat = (void*)(base_address + 0x0000ee30);
+    Symbol_Ctor = (void*)(base_address + 0x00256fd0);
+    SystemOptionsLoad = (void*)(base_address + 0x011b2310);
+    RBSystemOptionsSave = (void*)(base_address + 0x00d667c0);
 
     HOOK(DataInitFuncs);
     HOOK(SystemOptionsLoad);

--- a/source/plugin_common.c
+++ b/source/plugin_common.c
@@ -1,7 +1,30 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <stdbool.h>
 #include <GoldHEN/Common.h>
+#include "plugin_common.h"
+
+static uint64_t base_address = 0;
+
+// shadPS4 base address (old)
+//#define SHADPS4_BASE 0x8ffffc000
+
+// shadPS4 base address (new)
+#define SHADPS4_BASE 0x800000000 
+
+uint64_t get_base_address() {
+    if (base_address != 0) {
+        return base_address;
+    }
+    if (sys_sdk_proc_info(&procInfo) != 0) {
+        // syscall failed, probably shadPS4
+        base_address = SHADPS4_BASE;
+    } else {
+        base_address = procInfo.base_address;
+    }
+    return base_address;
+}
 
 bool file_exists(const char* filename) {
     struct stat buff;


### PR DESCRIPTION
* If the GoldHEN process info syscall fails, it uses a fixed base address.
* "get_base_address" function added to avoid having to use the info syscall every time
* In `NewFile`: Replaces the strcpy call with strcat and initialises the arrays with zero instead, to support old shadPS4

Not tested on real PS4 please make sure it didn't asplode